### PR TITLE
don't print the license in the description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     packages=find_packages(),
     extras_require={"testing": ["pytest"]},
-    license=f'{read("LICENSE.txt")}',
+    license='BSD-3-Clause',
     install_requires=install_requires,
     cmdclass=versioneer.get_cmdclass(),
     entry_points={"console_scripts": ["nbrr = nbrr.nbrr:NBRR"]},


### PR DESCRIPTION
This causes twine to choke for some reason.