### PR TITLE
Should fix the tests

### DIFF
--- a/tests/repo/notebook.ipynb
+++ b/tests/repo/notebook.ipynb
@@ -30,17 +30,6 @@
     "    fig, ax = plt.subplots()\n",
     "    ax.plot(dates, data)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "tree data | head -10"
-   ]
   }
  ],
  "metadata": {

--- a/tests/repo/notebook.ipynb
+++ b/tests/repo/notebook.ipynb
@@ -37,14 +37,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tree data | head -10"
+    "%%bash\n",
+    "\n",
+    "tree data | head -10"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -58,7 +60,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.13.5"
   },
   "livereveal": {
    "auto_select": "none",


### PR DESCRIPTION
The `!` is not longer parsed in the ast and this breaks depfinder. We should encourage the use of `%%bash` anyway to make the notebooks OS-agnostic.